### PR TITLE
feat: Implement Airtable vote aggregation system

### DIFF
--- a/backend/src/app/api/admin/cleanup-old-votes/route.ts
+++ b/backend/src/app/api/admin/cleanup-old-votes/route.ts
@@ -1,0 +1,200 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Airtable from 'airtable';
+
+// Configurazione Airtable
+const apiKey = process.env.AIRTABLE_API_KEY;
+const baseId = process.env.AIRTABLE_BASE_ID;
+
+if (!apiKey || !baseId) {
+  throw new Error('Credenziali Airtable mancanti nelle variabili d\'ambiente');
+}
+
+const base = Airtable.base(baseId);
+
+/**
+ * Endpoint amministrativo per pulire manualmente i voti vecchi
+ * Può essere usato per liberare spazio nella tabella votes dopo che i voti sono stati aggregati
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { matchIds, beforeDate, dryRun = true } = body;
+    
+    console.log('🗑️ ADMIN CLEANUP: Inizio pulizia voti vecchi');
+    console.log('Parametri:', { matchIds, beforeDate, dryRun });
+    
+    let filterFormula = '';
+    
+    if (matchIds && Array.isArray(matchIds) && matchIds.length > 0) {
+      // Pulisci voti per specifiche partite
+      const matchConditions = matchIds.map(id => `{matchId} = "${id}"`).join(', ');
+      filterFormula = `OR(${matchConditions})`;
+      console.log(`🎯 Modalità: Partite specifiche (${matchIds.length} partite)`);
+    } else if (beforeDate) {
+      // Pulisci voti prima di una certa data
+      filterFormula = `DATETIME_PARSE({Created}) < DATETIME_PARSE("${beforeDate}")`;
+      console.log(`📅 Modalità: Prima del ${beforeDate}`);
+    } else {
+      return NextResponse.json({
+        success: false,
+        error: 'Specificare matchIds o beforeDate per la pulizia'
+      }, { status: 400 });
+    }
+    
+    // Recupera i voti da cancellare
+    const voteRecords = await base('votes').select({
+      filterByFormula: filterFormula
+    }).all();
+    
+    console.log(`📊 Trovati ${voteRecords.length} voti da eliminare`);
+    
+    if (voteRecords.length === 0) {
+      return NextResponse.json({
+        success: true,
+        message: 'Nessun voto da eliminare',
+        deletedCount: 0,
+        dryRun
+      });
+    }
+    
+    // Raggruppa per matchId per statistiche
+    const votesByMatch = voteRecords.reduce((acc, record) => {
+      const matchId = record.get('matchId') as string;
+      if (!acc[matchId]) {
+        acc[matchId] = [];
+      }
+      acc[matchId].push(record);
+      return acc;
+    }, {} as Record<string, any[]>);
+    
+    console.log('📈 Distribuzione voti per partita:');
+    Object.entries(votesByMatch).forEach(([matchId, votes]) => {
+      console.log(`  ${matchId}: ${votes.length} voti`);
+    });
+    
+    if (dryRun) {
+      console.log('🔍 DRY RUN: Simulazione completata, nessun voto cancellato');
+      
+      return NextResponse.json({
+        success: true,
+        message: 'Dry run completato - nessun voto cancellato',
+        deletedCount: 0,
+        wouldDeleteCount: voteRecords.length,
+        matchBreakdown: Object.fromEntries(
+          Object.entries(votesByMatch).map(([matchId, votes]) => [matchId, votes.length])
+        ),
+        dryRun: true
+      });
+    }
+    
+    // Cancella i voti in batch (max 10 per volta per limitazioni Airtable)
+    let deletedCount = 0;
+    const batchSize = 10;
+    
+    for (let i = 0; i < voteRecords.length; i += batchSize) {
+      const batch = voteRecords.slice(i, i + batchSize);
+      const recordIds = batch.map(record => record.id);
+      
+      try {
+        await base('votes').destroy(recordIds);
+        deletedCount += recordIds.length;
+        console.log(`🗑️ Cancellati ${recordIds.length} voti (batch ${Math.floor(i / batchSize) + 1})`);
+      } catch (batchError) {
+        console.error(`❌ Errore nel batch ${Math.floor(i / batchSize) + 1}:`, batchError);
+        // Continua con il prossimo batch
+      }
+    }
+    
+    console.log(`✅ Pulizia completata: ${deletedCount}/${voteRecords.length} voti cancellati`);
+    
+    return NextResponse.json({
+      success: true,
+      message: `Pulizia completata: ${deletedCount} voti cancellati`,
+      deletedCount,
+      totalFound: voteRecords.length,
+      matchBreakdown: Object.fromEntries(
+        Object.entries(votesByMatch).map(([matchId, votes]) => [matchId, votes.length])
+      ),
+      dryRun: false
+    });
+    
+  } catch (error) {
+    console.error('❌ Errore nella pulizia voti:', error);
+    return NextResponse.json({
+      success: false,
+      error: 'Errore nella pulizia voti',
+      details: error instanceof Error ? error.message : 'Errore sconosciuto'
+    }, { status: 500 });
+  }
+}
+
+/**
+ * Endpoint per ottenere statistiche sui voti senza cancellarli
+ */
+export async function GET() {
+  try {
+    console.log('📊 ADMIN INFO: Recupero statistiche voti');
+    
+    // Conta tutti i voti
+    const allVotes = await base('votes').select({
+      fields: ['matchId', 'Created']
+    }).all();
+    
+    // Raggruppa per matchId
+    const votesByMatch = allVotes.reduce((acc, record) => {
+      const matchId = record.get('matchId') as string;
+      const created = record.get('Created') as string;
+      
+      if (!acc[matchId]) {
+        acc[matchId] = {
+          count: 0,
+          oldestDate: created,
+          newestDate: created
+        };
+      }
+      
+      acc[matchId].count++;
+      
+      if (new Date(created) < new Date(acc[matchId].oldestDate)) {
+        acc[matchId].oldestDate = created;
+      }
+      
+      if (new Date(created) > new Date(acc[matchId].newestDate)) {
+        acc[matchId].newestDate = created;
+      }
+      
+      return acc;
+    }, {} as Record<string, { count: number; oldestDate: string; newestDate: string }>);
+    
+    const totalVotes = allVotes.length;
+    const totalMatches = Object.keys(votesByMatch).length;
+    const avgVotesPerMatch = totalMatches > 0 ? (totalVotes / totalMatches) : 0;
+    
+    // Trova le partite con più voti
+    const topMatches = Object.entries(votesByMatch)
+      .sort(([,a], [,b]) => b.count - a.count)
+      .slice(0, 10)
+      .map(([matchId, data]) => ({ matchId, ...data }));
+    
+    return NextResponse.json({
+      success: true,
+      summary: {
+        totalVotes,
+        totalMatches,
+        avgVotesPerMatch: Math.round(avgVotesPerMatch * 10) / 10,
+        isApproachingLimit: totalVotes > 800, // Avviso quando si avvicina al limite
+        limitReached: totalVotes >= 1000
+      },
+      topMatches,
+      allMatches: votesByMatch
+    });
+    
+  } catch (error) {
+    console.error('❌ Errore nel recupero statistiche voti:', error);
+    return NextResponse.json({
+      success: false,
+      error: 'Errore nel recupero statistiche voti',
+      details: error instanceof Error ? error.message : 'Errore sconosciuto'
+    }, { status: 500 });
+  }
+} 

--- a/backend/src/app/api/debug/player-stats-check/route.ts
+++ b/backend/src/app/api/debug/player-stats-check/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Airtable from 'airtable';
+
+// Configurazione Airtable
+const apiKey = process.env.AIRTABLE_API_KEY;
+const baseId = process.env.AIRTABLE_BASE_ID;
+
+if (!apiKey || !baseId) {
+  throw new Error('Missing Airtable configuration in environment variables');
+}
+
+const base = Airtable.base(baseId);
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const email = searchParams.get('email');
+    
+    if (!email) {
+      return NextResponse.json({
+        success: false,
+        error: 'Email parameter required'
+      }, { status: 400 });
+    }
+    
+    console.log('🔍 DEBUG: Controllo dati per:', email);
+    
+    // 1. Controlla se esiste in player_stats
+    const playerStatsRecords = await base('player_stats').select({
+      filterByFormula: `{playerEmail} = "${email}"`
+    }).all();
+    
+    console.log('📊 Record trovati in player_stats:', playerStatsRecords.length);
+    
+    if (playerStatsRecords.length === 0) {
+      return NextResponse.json({
+        success: true,
+        debug: {
+          email,
+          foundInPlayerStats: false,
+          reason: 'Giocatore non trovato in player_stats',
+          willUseFallback: true
+        }
+      });
+    }
+    
+    const playerStatsRecord = playerStatsRecords[0];
+    const rawData = playerStatsRecord.fields;
+    
+    console.log('📋 Dati raw da player_stats:', rawData);
+    
+    // 2. Estrai i dati come fa l'API
+    const upVotes = Number(playerStatsRecord.get('upVotes')) || 0;
+    const downVotes = Number(playerStatsRecord.get('downVotes')) || 0;
+    const neutralVotes = Number(playerStatsRecord.get('neutralVotes')) || 0;
+    const motmVotes = Number(playerStatsRecord.get('motmVotes')) || 0;
+    
+    const totalVotes = upVotes + downVotes + neutralVotes;
+    const netVotes = upVotes - downVotes;
+    const upPercentage = totalVotes > 0 ? ((upVotes / totalVotes) * 100) : 0;
+    
+    console.log('🧮 Dati processati:', {
+      upVotes,
+      downVotes,
+      neutralVotes,
+      motmVotes,
+      totalVotes,
+      netVotes,
+      upPercentage
+    });
+    
+    // 3. Controlla se attiverà il fallback
+    const willUseFallback = totalVotes === 0;
+    
+    // 4. Se fallback, mostra anche un campione dalla tabella votes
+    let votesLegacySample = null;
+    if (willUseFallback) {
+      try {
+        const votesRecords = await base('votes').select({
+          filterByFormula: `{toPlayerId} = "${email}"`,
+          maxRecords: 10
+        }).all();
+        
+        votesLegacySample = {
+          totalVotesInVotesTable: votesRecords.length,
+          sampleVotes: votesRecords.slice(0, 3).map(vote => ({
+            voteType: vote.get('voteType'),
+            motmVote: vote.get('motm_vote'),
+            matchId: vote.get('matchId')
+          }))
+        };
+      } catch (votesError) {
+        votesLegacySample = { error: votesError instanceof Error ? votesError.message : 'Errore sconosciuto' };
+      }
+    }
+    
+    return NextResponse.json({
+      success: true,
+      debug: {
+        email,
+        foundInPlayerStats: true,
+        rawPlayerStatsData: rawData,
+        processedData: {
+          upVotes,
+          downVotes,
+          neutralVotes,
+          motmVotes,
+          totalVotes,
+          netVotes,
+          upPercentage: parseFloat(upPercentage.toFixed(1))
+        },
+        willUseFallback,
+        fallbackReason: willUseFallback ? 'totalVotes === 0' : null,
+        votesLegacySample
+      }
+    });
+    
+  } catch (error) {
+    console.error('❌ Errore nel debug player-stats:', error);
+    return NextResponse.json({
+      success: false,
+      error: 'Errore nel debug',
+      details: error instanceof Error ? error.message : 'Errore sconosciuto'
+    }, { status: 500 });
+  }
+} 

--- a/backend/src/utils/voteAggregation.ts
+++ b/backend/src/utils/voteAggregation.ts
@@ -1,0 +1,213 @@
+import Airtable from 'airtable';
+
+// Configurazione Airtable
+const apiKey = process.env.AIRTABLE_API_KEY;
+const baseId = process.env.AIRTABLE_BASE_ID;
+
+if (!apiKey || !baseId) {
+  throw new Error('Credenziali Airtable mancanti nelle variabili d\'ambiente');
+}
+
+const base = Airtable.base(baseId);
+
+// Interfaccia per i dati aggregati dei voti
+interface VoteAggregation {
+  playerEmail: string;
+  upVotes: number;
+  downVotes: number;
+  neutralVotes: number;
+  motmVotes: number;
+  totalVotes: number;
+  netVotes: number;
+}
+
+/**
+ * Funzione per aggregare i voti di una specifica partita
+ * @param matchId - ID della partita da aggregare
+ * @returns Array di aggregazioni per giocatore
+ */
+export async function aggregateVotesForMatch(matchId: string): Promise<VoteAggregation[]> {
+  try {
+    console.log('🔄 Aggregazione voti per partita:', matchId);
+    
+    // Recupera tutti i voti per questa partita
+    const voteRecords = await base('votes').select({
+      filterByFormula: `{matchId} = "${matchId}"`
+    }).all();
+    
+    console.log(`📊 Trovati ${voteRecords.length} voti per la partita ${matchId}`);
+    
+    // Raggruppa i voti per giocatore votato (toPlayerId)
+    const votesByPlayer: { [playerEmail: string]: VoteAggregation } = {};
+    
+    voteRecords.forEach(record => {
+      const toPlayerId = record.get('toPlayerId') as string;
+      const voteType = record.get('voteType') as string;
+      const motmVote = record.get('motm_vote') as boolean;
+      
+      if (!votesByPlayer[toPlayerId]) {
+        votesByPlayer[toPlayerId] = {
+          playerEmail: toPlayerId,
+          upVotes: 0,
+          downVotes: 0,
+          neutralVotes: 0,
+          motmVotes: 0,
+          totalVotes: 0,
+          netVotes: 0
+        };
+      }
+      
+      // Conta i tipi di voto
+      if (voteType === 'UP') {
+        votesByPlayer[toPlayerId].upVotes++;
+      } else if (voteType === 'DOWN') {
+        votesByPlayer[toPlayerId].downVotes++;
+      } else if (voteType === 'NEUTRAL') {
+        votesByPlayer[toPlayerId].neutralVotes++;
+      }
+      
+      // Conta i voti MOTM
+      if (motmVote) {
+        votesByPlayer[toPlayerId].motmVotes++;
+      }
+      
+      votesByPlayer[toPlayerId].totalVotes++;
+    });
+    
+    // Calcola netVotes per ogni giocatore
+    Object.values(votesByPlayer).forEach(aggregation => {
+      aggregation.netVotes = aggregation.upVotes - aggregation.downVotes;
+    });
+    
+    const aggregations = Object.values(votesByPlayer);
+    console.log(`✅ Aggregazione completata per ${aggregations.length} giocatori`);
+    
+    return aggregations;
+    
+  } catch (error) {
+    console.error('❌ Errore nell\'aggregazione voti:', error);
+    throw error;
+  }
+}
+
+/**
+ * Funzione per aggiornare le statistiche aggregate di un giocatore in player_stats
+ * @param playerEmail - Email del giocatore
+ * @param voteAggregation - Dati aggregati dei voti da aggiungere
+ */
+export async function updatePlayerStatsWithVotes(
+  playerEmail: string, 
+  voteAggregation: VoteAggregation
+): Promise<void> {
+  try {
+    console.log(`🔄 Aggiornamento statistiche voti per ${playerEmail}:`, voteAggregation);
+    
+    // Trova il record del giocatore in player_stats
+    const playerRecords = await base('player_stats').select({
+      filterByFormula: `{playerEmail} = "${playerEmail}"`
+    }).all();
+    
+    if (playerRecords.length === 0) {
+      console.log(`⚠️ Giocatore ${playerEmail} non trovato in player_stats, creo nuovo record`);
+      
+      // ✅ Crea nuovo record con i campi confermati dall'immagine Airtable dell'utente
+      await base('player_stats').create({
+        playerEmail: playerEmail,
+        Gol: 0,
+        partiteDisputate: 0,
+        partiteVinte: 0,
+        partitePareggiate: 0,
+        partitePerse: 0,
+        assistenze: 0,
+        cartelliniGialli: 0,
+        cartelliniRossi: 0,
+        // ✅ Campi per i voti aggregati - nomi confermati dall'immagine
+        upVotes: voteAggregation.upVotes,
+        downVotes: voteAggregation.downVotes,
+        neutralVotes: voteAggregation.neutralVotes,
+        motmVotes: voteAggregation.motmVotes
+      });
+      
+    } else {
+      const playerRecord = playerRecords[0];
+      const currentUpVotes = Number(playerRecord.get('upVotes')) || 0;
+      const currentDownVotes = Number(playerRecord.get('downVotes')) || 0;
+      const currentNeutralVotes = Number(playerRecord.get('neutralVotes')) || 0;
+      const currentMotmVotes = Number(playerRecord.get('motmVotes')) || 0;
+      
+      // ✅ Aggiorna aggiungendo i nuovi voti a quelli esistenti
+      await base('player_stats').update(playerRecord.id, {
+        upVotes: currentUpVotes + voteAggregation.upVotes,
+        downVotes: currentDownVotes + voteAggregation.downVotes,
+        neutralVotes: currentNeutralVotes + voteAggregation.neutralVotes,
+        motmVotes: currentMotmVotes + voteAggregation.motmVotes
+      });
+    }
+    
+    console.log(`✅ Statistiche voti aggiornate per ${playerEmail}`);
+    
+  } catch (error) {
+    console.error(`❌ Errore nell'aggiornamento statistiche per ${playerEmail}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Funzione per processare tutti i voti di una partita e aggiornarli in player_stats
+ * @param matchId - ID della partita da processare
+ */
+export async function processMatchVotesToPlayerStats(matchId: string): Promise<void> {
+  try {
+    console.log('🚀 Processamento voti per player_stats, partita:', matchId);
+    
+    // 1. Aggrega i voti per questa partita
+    const aggregations = await aggregateVotesForMatch(matchId);
+    
+    // 2. Aggiorna player_stats per ogni giocatore
+    for (const aggregation of aggregations) {
+      await updatePlayerStatsWithVotes(aggregation.playerEmail, aggregation);
+    }
+    
+    console.log(`✅ Processamento completato per ${aggregations.length} giocatori`);
+    
+  } catch (error) {
+    console.error('❌ Errore nel processamento voti per player_stats:', error);
+    throw error;
+  }
+}
+
+/**
+ * Funzione per cancellare i voti di una partita dalla tabella votes
+ * @param matchId - ID della partita di cui cancellare i voti
+ */
+export async function cleanupMatchVotes(matchId: string): Promise<void> {
+  try {
+    console.log('🗑️ Cancellazione voti vecchi per partita:', matchId);
+    
+    // Recupera tutti i voti per questa partita
+    const voteRecords = await base('votes').select({
+      filterByFormula: `{matchId} = "${matchId}"`
+    }).all();
+    
+    if (voteRecords.length === 0) {
+      console.log('⚠️ Nessun voto da cancellare');
+      return;
+    }
+    
+    // Cancella i record in batch (max 10 per volta per limitazioni Airtable)
+    const batchSize = 10;
+    for (let i = 0; i < voteRecords.length; i += batchSize) {
+      const batch = voteRecords.slice(i, i + batchSize);
+      const recordIds = batch.map(record => record.id);
+      
+      await base('votes').destroy(recordIds);
+      console.log(`🗑️ Cancellati ${recordIds.length} voti (batch ${Math.floor(i / batchSize) + 1})`);
+    }
+    
+    console.log(`✅ Cancellazione completata: ${voteRecords.length} voti rimossi`);
+    
+  } catch (error) {
+    console.error('❌ Errore nella cancellazione voti:', error);
+    throw error;
+  }
+} 

--- a/frontend/src/app/profile/[email]/page.tsx
+++ b/frontend/src/app/profile/[email]/page.tsx
@@ -424,8 +424,9 @@ export default function PlayerProfile() {
           if (voteResponse.ok) {
             const voteData = await voteResponse.json();
             if (voteData.success) {
-              console.log('📊 Dati voti caricati da:', voteData.source || 'unknown');
-              console.log('📈 Statistiche voti:', voteData.statistics);
+              console.log('📊 STRATEGIA IBRIDA - Dati da:', voteData.source || 'unknown');
+              console.log('📈 Statistiche (da player_stats):', voteData.statistics);
+              console.log('🎯 Ultima partita (da votes):', voteData.matchResults?.length || 0, 'risultati');
               setVoteHistory(voteData);
             }
           }
@@ -1689,9 +1690,15 @@ export default function PlayerProfile() {
                 </div>
 
                 {/* ✅ NUOVO: Gestione intelligente risultati */}
-                {voteHistory.matchResults && voteHistory.matchResults.length > 0 ? (
+                {/* ✅ STRATEGIA IBRIDA: Risultati ultima partita dalla tabella votes */}
+                {voteHistory.matchResults && voteHistory.matchResults.length > 0 && (
                   <div className="mb-6">
-                    <h3 className="text-lg font-semibold text-white font-runtime mb-4">Risultati ultima partita</h3>
+                    <h3 className="text-lg font-semibold text-white font-runtime mb-4">
+                      Risultati ultima partita
+                      {voteHistory.source === 'hybrid_player_stats_and_votes' && (
+                        <span className="text-sm text-blue-400 ml-2">(Live da votes)</span>
+                      )}
+                    </h3>
                     <div className="bg-gray-700/50 rounded-lg p-4">
                       {(() => {
                         const lastMatch = voteHistory.matchResults[0];
@@ -1728,44 +1735,7 @@ export default function PlayerProfile() {
                       })()}
                     </div>
                   </div>
-                ) : voteHistory.source === 'player_stats' && voteHistory.statistics.totalVotes > 0 ? (
-                  <div className="mb-6">
-                    <h3 className="text-lg font-semibold text-white font-runtime mb-4">
-                      📊 Totali Aggregati 
-                      <span className="text-sm text-green-400 ml-2">(Da player_stats)</span>
-                    </h3>
-                    <div className="bg-gray-700/50 rounded-lg p-4">
-                      <div className="flex items-center justify-center space-x-2">
-                        <div className="flex items-center space-x-2">
-                          <span className="bg-green-600 text-white px-2 py-1 rounded text-xs font-runtime font-semibold min-w-[45px] text-center">
-                            {voteHistory.statistics.upVotes} UP
-                          </span>
-                          {voteHistory.statistics.neutralVotes > 0 && (
-                            <span className="bg-gray-500 text-white px-2 py-1 rounded text-xs font-runtime font-semibold min-w-[45px] text-center">
-                              {voteHistory.statistics.neutralVotes} NEU
-                            </span>
-                          )}
-                          <span className="bg-red-600 text-white px-2 py-1 rounded text-xs font-runtime font-semibold min-w-[45px] text-center">
-                            {voteHistory.statistics.downVotes} DOWN
-                          </span>
-                          {voteHistory.statistics.motmVotes > 0 && (
-                            <span className="bg-amber-500 text-black px-2 py-1 rounded text-xs font-runtime font-bold min-w-[45px] text-center">
-                              {voteHistory.statistics.motmVotes} MOTM
-                            </span>
-                          )}
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          <div className={`font-runtime font-bold text-sm ${
-                            voteHistory.statistics.netVotes > 0 ? 'text-green-400' :
-                            voteHistory.statistics.netVotes < 0 ? 'text-red-400' : 'text-gray-400'
-                          }`}>
-                            Net: {voteHistory.statistics.netVotes > 0 ? '+' : ''}{voteHistory.statistics.netVotes}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ) : null}
+                )}
               </div>
             )}
           </div>

--- a/frontend/src/app/profile/[email]/page.tsx
+++ b/frontend/src/app/profile/[email]/page.tsx
@@ -43,7 +43,7 @@ interface VoteHistory {
   votes: Array<{
     id: string;
     voterEmail: string;
-    voteType: string; // 'UP' o 'DOWN'
+    voteType: string; // 'UP', 'DOWN', 'NEUTRAL'
     matchId: string;
     toPlayerId: string;
   }>;
@@ -51,18 +51,25 @@ interface VoteHistory {
     totalVotes: number;
     upVotes: number;
     downVotes: number;
+    neutralVotes: number; // ✅ AGGIUNTO
+    motmVotes: number;    // ✅ AGGIUNTO
     netVotes: number;
     upPercentage: number;
     totalMatches: number;
     actualMotm: number;
+    motmCandidacies?: number; // ✅ AGGIUNTO (opzionale per compatibilità)
   };
   matchResults: Array<{
     matchId: string;
     upVotes: number;
     downVotes: number;
+    neutralVotes?: number; // ✅ AGGIUNTO (opzionale per compatibilità)
+    motmVotes?: number;    // ✅ AGGIUNTO (opzionale per compatibilità)
     netVotes: number;
     isMotm: boolean;
+    wasMotmCandidate?: boolean; // ✅ AGGIUNTO (opzionale per compatibilità)
   }>;
+  source?: string; // ✅ AGGIUNTO per debug (da quale tabella vengono i dati)
 }
 
 interface PlayerAward {
@@ -417,6 +424,8 @@ export default function PlayerProfile() {
           if (voteResponse.ok) {
             const voteData = await voteResponse.json();
             if (voteData.success) {
+              console.log('📊 Dati voti caricati da:', voteData.source || 'unknown');
+              console.log('📈 Statistiche voti:', voteData.statistics);
               setVoteHistory(voteData);
             }
           }
@@ -1679,8 +1688,8 @@ export default function PlayerProfile() {
                   </div>
                 </div>
 
-                {/* Risultati ultima partita */}
-                {voteHistory.matchResults && voteHistory.matchResults.length > 0 && (
+                {/* ✅ NUOVO: Gestione intelligente risultati */}
+                {voteHistory.matchResults && voteHistory.matchResults.length > 0 ? (
                   <div className="mb-6">
                     <h3 className="text-lg font-semibold text-white font-runtime mb-4">Risultati ultima partita</h3>
                     <div className="bg-gray-700/50 rounded-lg p-4">
@@ -1690,17 +1699,17 @@ export default function PlayerProfile() {
                           <div className="flex items-center justify-center space-x-2">
                             <div className="flex items-center space-x-2">
                               <span className="bg-green-600 text-white px-2 py-1 rounded text-xs font-runtime font-semibold min-w-[45px] text-center">
-                                {lastMatch.upVotes} UP
+                                {lastMatch.upVotes || 0} UP
                               </span>
-                              {lastMatch.neutralVotes > 0 && (
+                              {(lastMatch.neutralVotes || 0) > 0 && (
                                 <span className="bg-gray-500 text-white px-2 py-1 rounded text-xs font-runtime font-semibold min-w-[45px] text-center">
                                   {lastMatch.neutralVotes} NEU
                                 </span>
                               )}
                               <span className="bg-red-600 text-white px-2 py-1 rounded text-xs font-runtime font-semibold min-w-[45px] text-center">
-                                {lastMatch.downVotes} DOWN
+                                {lastMatch.downVotes || 0} DOWN
                               </span>
-                              {lastMatch.motmVotes > 0 && (
+                              {(lastMatch.motmVotes || 0) > 0 && (
                                 <span className="bg-amber-500 text-black px-2 py-1 rounded text-xs font-runtime font-bold min-w-[45px] text-center">
                                   {lastMatch.motmVotes} MOTM
                                 </span>
@@ -1708,10 +1717,10 @@ export default function PlayerProfile() {
                             </div>
                             <div className="flex items-center space-x-2">
                               <div className={`font-runtime font-bold text-sm ${
-                                lastMatch.netVotes > 0 ? 'text-green-400' :
-                                lastMatch.netVotes < 0 ? 'text-red-400' : 'text-gray-400'
+                                (lastMatch.netVotes || 0) > 0 ? 'text-green-400' :
+                                (lastMatch.netVotes || 0) < 0 ? 'text-red-400' : 'text-gray-400'
                               }`}>
-                                Net: {lastMatch.netVotes > 0 ? '+' : ''}{lastMatch.netVotes}
+                                Net: {(lastMatch.netVotes || 0) > 0 ? '+' : ''}{lastMatch.netVotes || 0}
                               </div>
                             </div>
                           </div>
@@ -1719,7 +1728,44 @@ export default function PlayerProfile() {
                       })()}
                     </div>
                   </div>
-                )}
+                ) : voteHistory.source === 'player_stats' && voteHistory.statistics.totalVotes > 0 ? (
+                  <div className="mb-6">
+                    <h3 className="text-lg font-semibold text-white font-runtime mb-4">
+                      📊 Totali Aggregati 
+                      <span className="text-sm text-green-400 ml-2">(Da player_stats)</span>
+                    </h3>
+                    <div className="bg-gray-700/50 rounded-lg p-4">
+                      <div className="flex items-center justify-center space-x-2">
+                        <div className="flex items-center space-x-2">
+                          <span className="bg-green-600 text-white px-2 py-1 rounded text-xs font-runtime font-semibold min-w-[45px] text-center">
+                            {voteHistory.statistics.upVotes} UP
+                          </span>
+                          {voteHistory.statistics.neutralVotes > 0 && (
+                            <span className="bg-gray-500 text-white px-2 py-1 rounded text-xs font-runtime font-semibold min-w-[45px] text-center">
+                              {voteHistory.statistics.neutralVotes} NEU
+                            </span>
+                          )}
+                          <span className="bg-red-600 text-white px-2 py-1 rounded text-xs font-runtime font-semibold min-w-[45px] text-center">
+                            {voteHistory.statistics.downVotes} DOWN
+                          </span>
+                          {voteHistory.statistics.motmVotes > 0 && (
+                            <span className="bg-amber-500 text-black px-2 py-1 rounded text-xs font-runtime font-bold min-w-[45px] text-center">
+                              {voteHistory.statistics.motmVotes} MOTM
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex items-center space-x-2">
+                          <div className={`font-runtime font-bold text-sm ${
+                            voteHistory.statistics.netVotes > 0 ? 'text-green-400' :
+                            voteHistory.statistics.netVotes < 0 ? 'text-red-400' : 'text-gray-400'
+                          }`}>
+                            Net: {voteHistory.statistics.netVotes > 0 ? '+' : ''}{voteHistory.statistics.netVotes}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
               </div>
             )}
           </div>

--- a/netlify/functions/cleanup-old-votes.js
+++ b/netlify/functions/cleanup-old-votes.js
@@ -1,0 +1,259 @@
+const Airtable = require('airtable');
+
+exports.handler = async (event, context) => {
+  // Gestione CORS
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+    'Content-Type': 'application/json'
+  };
+
+  // Gestione preflight OPTIONS
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers,
+      body: ''
+    };
+  }
+
+  // Configurazione Airtable
+  const airtable = new Airtable({
+    apiKey: process.env.AIRTABLE_API_KEY,
+  });
+
+  const apiKey = process.env.AIRTABLE_API_KEY;
+  const baseId = process.env.AIRTABLE_BASE_ID;
+
+  if (!apiKey || !baseId) {
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({
+        success: false,
+        error: 'Credenziali Airtable mancanti nelle variabili d\'ambiente'
+      })
+    };
+  }
+
+  const base = Airtable.base(baseId);
+
+  if (event.httpMethod === 'POST') {
+    // Endpoint per pulizia voti vecchi
+    try {
+      const body = JSON.parse(event.body || '{}');
+      const { matchIds, beforeDate, dryRun = true } = body;
+      
+      console.log('🗑️ ADMIN CLEANUP: Inizio pulizia voti vecchi');
+      console.log('Parametri:', { matchIds, beforeDate, dryRun });
+      
+      let filterFormula = '';
+      
+      if (matchIds && Array.isArray(matchIds) && matchIds.length > 0) {
+        // Pulisci voti per specifiche partite
+        const matchConditions = matchIds.map(id => `{matchId} = "${id}"`).join(', ');
+        filterFormula = `OR(${matchConditions})`;
+        console.log(`🎯 Modalità: Partite specifiche (${matchIds.length} partite)`);
+      } else if (beforeDate) {
+        // Pulisci voti prima di una certa data
+        filterFormula = `DATETIME_PARSE({Created}) < DATETIME_PARSE("${beforeDate}")`;
+        console.log(`📅 Modalità: Prima del ${beforeDate}`);
+      } else {
+        return {
+          statusCode: 400,
+          headers,
+          body: JSON.stringify({
+            success: false,
+            error: 'Specificare matchIds o beforeDate per la pulizia'
+          })
+        };
+      }
+      
+      // Recupera i voti da cancellare
+      const voteRecords = await base('votes').select({
+        filterByFormula: filterFormula
+      }).all();
+      
+      console.log(`📊 Trovati ${voteRecords.length} voti da eliminare`);
+      
+      if (voteRecords.length === 0) {
+        return {
+          statusCode: 200,
+          headers,
+          body: JSON.stringify({
+            success: true,
+            message: 'Nessun voto da eliminare',
+            deletedCount: 0,
+            dryRun
+          })
+        };
+      }
+      
+      // Raggruppa per matchId per statistiche
+      const votesByMatch = voteRecords.reduce((acc, record) => {
+        const matchId = record.get('matchId');
+        if (!acc[matchId]) {
+          acc[matchId] = [];
+        }
+        acc[matchId].push(record);
+        return acc;
+      }, {});
+      
+      console.log('📈 Distribuzione voti per partita:');
+      Object.entries(votesByMatch).forEach(([matchId, votes]) => {
+        console.log(`  ${matchId}: ${votes.length} voti`);
+      });
+      
+      if (dryRun) {
+        console.log('🔍 DRY RUN: Simulazione completata, nessun voto cancellato');
+        
+        return {
+          statusCode: 200,
+          headers,
+          body: JSON.stringify({
+            success: true,
+            message: 'Dry run completato - nessun voto cancellato',
+            deletedCount: 0,
+            wouldDeleteCount: voteRecords.length,
+            matchBreakdown: Object.fromEntries(
+              Object.entries(votesByMatch).map(([matchId, votes]) => [matchId, votes.length])
+            ),
+            dryRun: true
+          })
+        };
+      }
+      
+      // Cancella i voti in batch (max 10 per volta per limitazioni Airtable)
+      let deletedCount = 0;
+      const batchSize = 10;
+      
+      for (let i = 0; i < voteRecords.length; i += batchSize) {
+        const batch = voteRecords.slice(i, i + batchSize);
+        const recordIds = batch.map(record => record.id);
+        
+        try {
+          await base('votes').destroy(recordIds);
+          deletedCount += recordIds.length;
+          console.log(`🗑️ Cancellati ${recordIds.length} voti (batch ${Math.floor(i / batchSize) + 1})`);
+        } catch (batchError) {
+          console.error(`❌ Errore nel batch ${Math.floor(i / batchSize) + 1}:`, batchError);
+          // Continua con il prossimo batch
+        }
+      }
+      
+      console.log(`✅ Pulizia completata: ${deletedCount}/${voteRecords.length} voti cancellati`);
+      
+      return {
+        statusCode: 200,
+        headers,
+        body: JSON.stringify({
+          success: true,
+          message: `Pulizia completata: ${deletedCount} voti cancellati`,
+          deletedCount,
+          totalFound: voteRecords.length,
+          matchBreakdown: Object.fromEntries(
+            Object.entries(votesByMatch).map(([matchId, votes]) => [matchId, votes.length])
+          ),
+          dryRun: false
+        })
+      };
+      
+    } catch (error) {
+      console.error('❌ Errore nella pulizia voti:', error);
+      return {
+        statusCode: 500,
+        headers,
+        body: JSON.stringify({
+          success: false,
+          error: 'Errore nella pulizia voti',
+          details: error.message || 'Errore sconosciuto'
+        })
+      };
+    }
+  }
+
+  if (event.httpMethod === 'GET') {
+    // Endpoint per statistiche voti
+    try {
+      console.log('📊 ADMIN INFO: Recupero statistiche voti');
+      
+      // Conta tutti i voti
+      const allVotes = await base('votes').select({
+        fields: ['matchId', 'Created']
+      }).all();
+      
+      // Raggruppa per matchId
+      const votesByMatch = allVotes.reduce((acc, record) => {
+        const matchId = record.get('matchId');
+        const created = record.get('Created');
+        
+        if (!acc[matchId]) {
+          acc[matchId] = {
+            count: 0,
+            oldestDate: created,
+            newestDate: created
+          };
+        }
+        
+        acc[matchId].count++;
+        
+        if (new Date(created) < new Date(acc[matchId].oldestDate)) {
+          acc[matchId].oldestDate = created;
+        }
+        
+        if (new Date(created) > new Date(acc[matchId].newestDate)) {
+          acc[matchId].newestDate = created;
+        }
+        
+        return acc;
+      }, {});
+      
+      const totalVotes = allVotes.length;
+      const totalMatches = Object.keys(votesByMatch).length;
+      const avgVotesPerMatch = totalMatches > 0 ? (totalVotes / totalMatches) : 0;
+      
+      // Trova le partite con più voti
+      const topMatches = Object.entries(votesByMatch)
+        .sort(([,a], [,b]) => b.count - a.count)
+        .slice(0, 10)
+        .map(([matchId, data]) => ({ matchId, ...data }));
+      
+      return {
+        statusCode: 200,
+        headers,
+        body: JSON.stringify({
+          success: true,
+          summary: {
+            totalVotes,
+            totalMatches,
+            avgVotesPerMatch: Math.round(avgVotesPerMatch * 10) / 10,
+            isApproachingLimit: totalVotes > 800, // Avviso quando si avvicina al limite
+            limitReached: totalVotes >= 1000
+          },
+          topMatches,
+          allMatches: votesByMatch
+        })
+      };
+      
+    } catch (error) {
+      console.error('❌ Errore nel recupero statistiche voti:', error);
+      return {
+        statusCode: 500,
+        headers,
+        body: JSON.stringify({
+          success: false,
+          error: 'Errore nel recupero statistiche voti',
+          details: error.message || 'Errore sconosciuto'
+        })
+      };
+    }
+  }
+
+  // Metodo non supportato
+  return {
+    statusCode: 405,
+    headers,
+    body: JSON.stringify({ error: 'Metodo non supportato' })
+  };
+}; 

--- a/netlify/functions/debug-player-stats-check.js
+++ b/netlify/functions/debug-player-stats-check.js
@@ -1,0 +1,158 @@
+const Airtable = require('airtable');
+
+exports.handler = async (event, context) => {
+  // Gestione CORS
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+    'Content-Type': 'application/json'
+  };
+
+  // Gestione preflight OPTIONS
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers,
+      body: ''
+    };
+  }
+
+  // Solo GET è supportato per questa API
+  if (event.httpMethod !== 'GET') {
+    return {
+      statusCode: 405,
+      headers,
+      body: JSON.stringify({ error: 'Metodo non consentito' })
+    };
+  }
+
+  try {
+    // Estrai l'email dai query parameters
+    const email = event.queryStringParameters?.email;
+    
+    if (!email) {
+      return {
+        statusCode: 400,
+        headers,
+        body: JSON.stringify({ error: 'Email mancante nei query parameters' })
+      };
+    }
+
+    console.log('🔍 Debug check per email:', email);
+
+    // Configurazione Airtable
+    const airtable = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    });
+
+    const apiKey = process.env.AIRTABLE_API_KEY;
+    const baseId = process.env.AIRTABLE_BASE_ID;
+
+    if (!apiKey || !baseId) {
+      throw new Error('Missing Airtable configuration in environment variables');
+    }
+
+    const base = Airtable.base(baseId);
+
+    // 1. Controlla player_stats
+    let playerStatsCheck = {
+      found: false,
+      rawData: null,
+      processedData: null,
+      error: null
+    };
+
+    try {
+      const playerStatsRecords = await base('player_stats').select({
+        filterByFormula: `{playerEmail} = "${email}"`
+      }).firstPage();
+
+      if (playerStatsRecords && playerStatsRecords.length > 0) {
+        const record = playerStatsRecords[0];
+        playerStatsCheck.found = true;
+        playerStatsCheck.rawData = {
+          id: record.id,
+          fields: record.fields
+        };
+
+        const upVotes = record.get('upVotes') || 0;
+        const downVotes = record.get('downVotes') || 0;
+        const neutralVotes = record.get('neutralVotes') || 0;
+        const motmVotes = record.get('motmVotes') || 0;
+
+        playerStatsCheck.processedData = {
+          upVotes,
+          downVotes,
+          neutralVotes,
+          motmVotes,
+          totalVotes: upVotes + downVotes + neutralVotes,
+          netVotes: upVotes - downVotes
+        };
+      }
+    } catch (error) {
+      playerStatsCheck.error = error.message;
+    }
+
+    // 2. Controlla se si userebbe fallback
+    const wouldFallbackToVotes = !playerStatsCheck.found;
+
+    // 3. Se fallback, mostra un campione di votes
+    let votesSample = null;
+    if (wouldFallbackToVotes) {
+      try {
+        const votesRecords = await base('votes').select({
+          filterByFormula: `{toPlayerId} = "${email}"`,
+          maxRecords: 5,
+          sort: [{ field: 'matchId', direction: 'desc' }]
+        }).all();
+
+        votesSample = {
+          totalFound: votesRecords.length,
+          sample: votesRecords.map(record => ({
+            id: record.id,
+            voteType: record.get('voteType'),
+            motmVote: record.get('motm_vote') || false,
+            matchId: record.get('matchId'),
+            fromPlayerId: record.get('fromPlayerId')
+          }))
+        };
+      } catch (error) {
+        votesSample = { error: error.message };
+      }
+    }
+
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({
+        success: true,
+        email: email,
+        timestamp: new Date().toISOString(),
+        playerStatsCheck,
+        wouldFallbackToVotes,
+        votesSample,
+        summary: {
+          playerStatsAvailable: playerStatsCheck.found,
+          dataSource: playerStatsCheck.found ? 'player_stats' : 'votes_fallback',
+          upVotes: playerStatsCheck.processedData?.upVotes || 'N/A',
+          downVotes: playerStatsCheck.processedData?.downVotes || 'N/A',
+          neutralVotes: playerStatsCheck.processedData?.neutralVotes || 'N/A',
+          motmVotes: playerStatsCheck.processedData?.motmVotes || 'N/A'
+        }
+      })
+    };
+
+  } catch (error) {
+    console.error('Errore nel debug player stats check:', error);
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({
+        success: false,
+        error: 'Errore nel debug player stats check',
+        details: error.message || 'Errore sconosciuto'
+      })
+    };
+  }
+}; 

--- a/netlify/functions/votes-history.js
+++ b/netlify/functions/votes-history.js
@@ -41,7 +41,6 @@ exports.handler = async (event, context) => {
     }
 
     const email = decodeURIComponent(emailEncoded);
-    console.log('Ricerca storico votazioni completo per:', email);
 
     // Configurazione Airtable
     const airtable = new Airtable({
@@ -57,108 +56,184 @@ exports.handler = async (event, context) => {
 
     const base = Airtable.base(baseId);
 
-    // ✅ Recupera tutti i voti ricevuti (UP, DOWN, NEUTRAL, MOTM)
-    const records = await base('votes').select({
-      filterByFormula: `{toPlayerId} = "${email}"`,
-      sort: [{ field: 'matchId', direction: 'desc' }]
-    }).all();
+    // ✅ NUOVO: Strategia ibrida - Totali da player_stats + ultima partita da votes
+    console.log('💡 Strategia ibrida: Totali da player_stats + ultima partita da votes');
 
-    console.log('Voti totali trovati:', records.length);
-
-    // Recupera i veri premi Man of the Match dalla tabella player_awards
-    let actualMotm = 0;
+    // 1. Prova a recuperare i totali aggregati da player_stats
+    let playerStatsRecord = null;
     try {
-      const awardsRecords = await base('player_awards').select({
-        filterByFormula: `AND({player_email} = "${email}", {award_type} = "motm")`
-      }).all();
-      actualMotm = awardsRecords.length;
-      console.log('Premi MotM effettivi trovati:', actualMotm);
-    } catch (awardsError) {
-      console.log('Tabella player_awards non disponibile, usando valore 0 per MotM');
-      actualMotm = 0;
+      const playerStatsRecords = await base('player_stats').select({
+        filterByFormula: `{playerEmail} = "${email}"`
+      }).firstPage();
+
+      if (playerStatsRecords && playerStatsRecords.length > 0) {
+        playerStatsRecord = playerStatsRecords[0];
+        console.log('✅ Player trovato in player_stats');
+      }
+    } catch (error) {
+      console.log('❌ Errore nel recupero da player_stats:', error.message);
     }
 
-    // ✅ Mappa i dati includendo NEUTRAL e MOTM
-    const votes = records.map(record => ({
-      id: record.id,
-      voterEmail: record.get('fromPlayerId'),
-      voteType: record.get('voteType'), // 'UP', 'DOWN' o 'NEUTRAL'
-      motmVote: record.get('motm_vote') || false, // Voto MOTM
-      matchId: record.get('matchId'),
-      toPlayerId: record.get('toPlayerId')
-    }));
+    // 2. Calcola statistiche da player_stats se disponibili
+    let statistics = null;
+    if (playerStatsRecord) {
+      const upVotes = playerStatsRecord.get('upVotes') || 0;
+      const downVotes = playerStatsRecord.get('downVotes') || 0;
+      const neutralVotes = playerStatsRecord.get('neutralVotes') || 0;
+      const motmVotes = playerStatsRecord.get('motmVotes') || 0;
 
-    // ✅ Calcola statistiche complete
-    const totalVotes = votes.length;
-    const upVotes = votes.filter(vote => vote.voteType === 'UP').length;
-    const downVotes = votes.filter(vote => vote.voteType === 'DOWN').length;
-    const neutralVotes = votes.filter(vote => vote.voteType === 'NEUTRAL').length;
-    const motmVotes = votes.filter(vote => vote.motmVote).length;
-    const netVotes = upVotes - downVotes; // NEUTRAL non influisce sul net
-    const upPercentage = totalVotes > 0 ? ((upVotes / totalVotes) * 100).toFixed(1) : '0';
+      const totalVotes = upVotes + downVotes + neutralVotes;
+      const netVotes = upVotes - downVotes;
+      const upPercentage = totalVotes > 0 ? ((upVotes / totalVotes) * 100).toFixed(1) : '0';
 
-    console.log('📊 Statistiche calcolate:', {
-      totalVotes,
-      upVotes,
-      downVotes,
-      neutralVotes,
-      motmVotes,
-      netVotes
+      // Recupera i veri premi Man of the Match dalla tabella player_awards
+      let actualMotm = 0;
+      try {
+        const awardsRecords = await base('player_awards').select({
+          filterByFormula: `AND({player_email} = "${email}", {award_type} = "motm")`
+        }).all();
+        actualMotm = awardsRecords.length;
+      } catch (awardsError) {
+        console.log('Tabella player_awards non disponibile, usando valore 0 per MotM');
+        actualMotm = 0;
+      }
+
+      statistics = {
+        totalVotes,
+        upVotes,
+        downVotes,
+        neutralVotes,
+        motmVotes,
+        netVotes,
+        upPercentage: parseFloat(upPercentage),
+        actualMotm,
+        motmCandidacies: motmVotes // Candidature MOTM
+      };
+
+      console.log('📊 Statistiche da player_stats:', statistics);
+    }
+
+    // 3. Recupera risultati ultima partita dalla tabella votes
+    let lastMatchResults = [];
+    try {
+      const recentVotesRecords = await base('votes').select({
+        filterByFormula: `{toPlayerId} = "${email}"`,
+        sort: [{ field: 'matchId', direction: 'desc' }],
+        maxRecords: 50 // Prendiamo gli ultimi 50 voti per essere sicuri
+      }).all();
+
+      if (recentVotesRecords && recentVotesRecords.length > 0) {
+        // Raggruppa per matchId per trovare l'ultima partita
+        const votesByMatch = recentVotesRecords.reduce((acc, record) => {
+          const matchId = record.get('matchId');
+          if (!acc[matchId]) {
+            acc[matchId] = { up: 0, down: 0, neutral: 0, motm: 0 };
+          }
+          
+          const voteType = record.get('voteType');
+          const motmVote = record.get('motm_vote') || false;
+          
+          if (voteType === 'UP') {
+            acc[matchId].up++;
+          } else if (voteType === 'DOWN') {
+            acc[matchId].down++;
+          } else if (voteType === 'NEUTRAL') {
+            acc[matchId].neutral++;
+          }
+          
+          if (motmVote) {
+            acc[matchId].motm++;
+          }
+          
+          return acc;
+        }, {});
+
+        // Converti in array e prendi solo l'ultima partita
+        lastMatchResults = Object.entries(votesByMatch).map(([matchId, votes]) => ({
+          matchId,
+          upVotes: votes.up,
+          downVotes: votes.down,
+          neutralVotes: votes.neutral,
+          motmVotes: votes.motm,
+          netVotes: votes.up - votes.down,
+          wasMotmCandidate: votes.motm > 0
+        })).slice(0, 1); // Solo ultima partita
+
+        console.log('🎯 Risultati ultima partita da votes:', lastMatchResults);
+      }
+    } catch (error) {
+      console.log('❌ Errore nel recupero da votes per ultima partita:', error.message);
+    }
+
+    // 4. Se non abbiamo statistics da player_stats, fallback a votes (vecchio comportamento)
+    if (!statistics) {
+      console.log('⚠️ Fallback: Calcolo da votes (player_stats non disponibile)');
+      
+      const allVotesRecords = await base('votes').select({
+        filterByFormula: `{toPlayerId} = "${email}"`,
+        sort: [{ field: 'matchId', direction: 'desc' }]
+      }).all();
+
+      const votes = allVotesRecords.map(record => ({
+        id: record.id,
+        voterEmail: record.get('fromPlayerId'),
+        voteType: record.get('voteType'),
+        motmVote: record.get('motm_vote') || false,
+        matchId: record.get('matchId'),
+        toPlayerId: record.get('toPlayerId')
+      }));
+
+      const totalVotes = votes.length;
+      const upVotes = votes.filter(vote => vote.voteType === 'UP').length;
+      const downVotes = votes.filter(vote => vote.voteType === 'DOWN').length;
+      const neutralVotes = votes.filter(vote => vote.voteType === 'NEUTRAL').length;
+      const motmVotes = votes.filter(vote => vote.motmVote).length;
+      const netVotes = upVotes - downVotes;
+      const upPercentage = totalVotes > 0 ? ((upVotes / totalVotes) * 100).toFixed(1) : '0';
+
+      // Recupera premi MotM effettivi
+      let actualMotm = 0;
+      try {
+        const awardsRecords = await base('player_awards').select({
+          filterByFormula: `AND({player_email} = "${email}", {award_type} = "motm")`
+        }).all();
+        actualMotm = awardsRecords.length;
+      } catch (awardsError) {
+        actualMotm = 0;
+      }
+
+      statistics = {
+        totalVotes,
+        upVotes,
+        downVotes,
+        neutralVotes,
+        motmVotes,
+        netVotes,
+        upPercentage: parseFloat(upPercentage),
+        actualMotm,
+        motmCandidacies: motmVotes
+      };
+    }
+
+    const responseData = {
+      success: true,
+      playerEmail: email,
+      votes: [], // I singoli voti non sono più necessari per il frontend
+      statistics: statistics,
+      matchResults: lastMatchResults, // ✅ NUOVO: Solo ultima partita dalla tabella votes
+      source: statistics && playerStatsRecord ? 'hybrid_player_stats_and_votes' : 'fallback_votes_only' // Indicatore per debug
+    };
+
+    console.log('✅ Risposta finale:', { 
+      source: responseData.source, 
+      hasStatistics: !!statistics, 
+      hasMatchResults: lastMatchResults.length > 0 
     });
-
-    // ✅ Statistiche per partita (raggruppa per matchId)
-    const votesByMatch = votes.reduce((acc, vote) => {
-      const matchId = vote.matchId;
-      if (!acc[matchId]) {
-        acc[matchId] = { up: 0, down: 0, neutral: 0, motm: 0 };
-      }
-      
-      if (vote.voteType === 'UP') {
-        acc[matchId].up++;
-      } else if (vote.voteType === 'DOWN') {
-        acc[matchId].down++;
-      } else if (vote.voteType === 'NEUTRAL') {
-        acc[matchId].neutral++;
-      }
-      
-      if (vote.motmVote) {
-        acc[matchId].motm++;
-      }
-      
-      return acc;
-    }, {});
-
-    const matchResults = Object.entries(votesByMatch).map(([matchId, votes]) => ({
-      matchId,
-      upVotes: votes.up,
-      downVotes: votes.down,
-      neutralVotes: votes.neutral,
-      motmVotes: votes.motm,
-      netVotes: votes.up - votes.down,
-      wasMotmCandidate: votes.motm > 0 // Se ha ricevuto voti MOTM
-    }));
 
     return {
       statusCode: 200,
       headers,
-      body: JSON.stringify({
-        success: true,
-        playerEmail: email,
-        votes,
-        statistics: {
-          totalVotes,
-          upVotes,
-          downVotes,
-          neutralVotes, // ✅ NUOVO
-          motmVotes,    // ✅ NUOVO
-          netVotes,
-          upPercentage: parseFloat(upPercentage),
-          totalMatches: Object.keys(votesByMatch).length,
-          actualMotm: actualMotm, // Veri premi MotM vinti
-          motmCandidacies: matchResults.filter(match => match.wasMotmCandidate).length // ✅ NUOVO
-        },
-        matchResults: matchResults.slice(0, 10) // Ultimi 10 match
-      })
+      body: JSON.stringify(responseData)
     };
 
   } catch (error) {


### PR DESCRIPTION
- Add vote aggregation functions in voteAggregation.ts
- Modify finalize-voting to aggregate votes to player_stats
- Update votes/history API to read from player_stats with fallback
- Add admin cleanup endpoint for old votes management
- Optimize Airtable usage by moving votes from 'votes' table to 'player_stats'
- Support for upVotes, downVotes, neutralVotes, motmVotes columns

This solves the Airtable 1000 rows limit issue by aggregating vote data.